### PR TITLE
use make-load-form for consifying specializer (works on CCL)

### DIFF
--- a/closer-mop-shared.lisp
+++ b/closer-mop-shared.lisp
@@ -511,7 +511,7 @@
       (loop for specializer-name in (extract-specializer-names specialized-args)
             collect (typecase specializer-name
                       (symbol `(find-class ',specializer-name))
-                      (class specializer-name)
+                      ((or class specializer) specializer-name)
                       (cons (cond
                              ((> (length specializer-name) 2)
                               (error "Invalid specializer ~S in defmethod form ~S."
@@ -520,7 +520,6 @@
                               `(intern-eql-specializer ,(cadr specializer-name)))
                              (t (error "Invalid specializer ~S in defmethod form ~S."
                                        specializer-name form))))
-		      (specializer (make-load-form specializer-name))
                       (t (error "Invalid specializer ~S in defmethod form ~S."
                                 specializer-name form)))))
     

--- a/closer-mop-shared.lisp
+++ b/closer-mop-shared.lisp
@@ -520,6 +520,7 @@
                               `(intern-eql-specializer ,(cadr specializer-name)))
                              (t (error "Invalid specializer ~S in defmethod form ~S."
                                        specializer-name form))))
+		      (specializer (make-load-form specializer-name))
                       (t (error "Invalid specializer ~S in defmethod form ~S."
                                 specializer-name form)))))
     


### PR DESCRIPTION
Currently closer-mop does not allow the usage of meta-specializers, due to limitations in extract-specializers. The current change consifies specializer objects by calling make-load-form. This also seems to be inline with how SBCL handles things (I think). I'm not entirely sure how it's dealt with in AMOP. 
