### PR TITLE
Fix .asd when loading on an unsupported lisp (e.g. clasp).

### DIFF
--- a/closer-clasp.lisp
+++ b/closer-clasp.lisp
@@ -1,0 +1,24 @@
+(in-package :closer-mop)
+
+;; TODO FIXME this below is untested
+(cl:defmethod compute-effective-method-function ((gf standard-generic-function) effective-method options)
+  (declare (optimize (speed 3) (space 0) (compilation-speed 0)))
+  (when options
+    (cerror "Ignore these options."
+            "This version of compute-effective-method-function does not support method combination options: ~S"
+            options))
+  (coerce `(lambda (.method-args. .next-methods. &rest passed-arguments)
+             ,effective-method)
+          'function)
+  ;; alternatively
+  #+nil
+  (coerce `(lambda (dummy-method-args .next-methods. &va-rest .method-args.)
+             ,effective-method)
+          'function))
+
+(declaim (inline eql-specializer-p))
+(defun eql-specializer-p (thing)
+  (typep thing 'eql-specializer))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (pushnew :closer-mop *features*))

--- a/closer-mop-packages.lisp
+++ b/closer-mop-packages.lisp
@@ -7,7 +7,7 @@
   #+(or allegro clozure lispworks mcl)
   (:shadow #:standard-class)
 
-  #+(or allegro clisp clozure ecl lispworks sbcl)
+  #+(or allegro clisp clozure ecl clasp lispworks sbcl)
   (:shadow #:defgeneric #:defmethod #:standard-generic-function)
 
   #+clozure (:shadow standard-method)
@@ -26,6 +26,7 @@
    #+clozure   #:ccl
    #+cmu       #:pcl
    #+ecl       #:clos
+   #+clasp     #:clos
    #+lispworks #:clos
    #+mcl       #:ccl
    #+sbcl      #:sb-pcl
@@ -39,6 +40,7 @@
    #+clozure   #:ccl
    #+cmu       #:clos-mop
    #+ecl       #:clos
+   #+clasp     #:clos
    #+lispworks #:clos
    #+mcl       #:ccl
    #+sbcl      #:sb-mop

--- a/closer-mop-shared.lisp
+++ b/closer-mop-shared.lisp
@@ -65,7 +65,7 @@
   (defun classp (thing)
     (typep thing 'class)))
 
-#+(or allegro clisp clozure ecl lispworks sbcl)
+#+(or allegro clisp clozure ecl clasp lispworks sbcl)
 (progn ;;; New generic functions.
 
   (defclass standard-generic-function (cl:standard-generic-function)
@@ -88,7 +88,7 @@
     (defclass standard-method (cl:standard-method)
       ((fn :initarg :real-function :reader method-function))))
 
-  #-ecl
+  #-(or ecl clasp)
   (progn
     (declaim (inline m-function))
     
@@ -131,7 +131,7 @@
 
   #-(or abcl sbcl) (cl:defgeneric make-method-lambda (generic-function method lambda-expression environment))
 
-  #-ecl
+  #-(or ecl clasp)
   (cl:defmethod make-method-lambda ((gf standard-generic-function) (method standard-method)
                                     lambda-expression environment)
     (declare (ignore environment) (optimize (speed 3) (space 0) (compilation-speed 0)))
@@ -199,7 +199,7 @@
 
   (cl:defgeneric compute-effective-method-function (gf effective-method options))
 
-  #-ecl
+  #-(or ecl clasp)
   (cl:defmethod compute-effective-method-function ((gf generic-function) effective-method options)
     (declare (optimize (speed 3) (space 0) (compilation-speed 0)))
     (when #-clisp options
@@ -615,7 +615,7 @@
 
     #+mcl (eval form)))
 
-#+(or abcl clozure ecl lispworks sbcl)
+#+(or abcl clozure ecl clasp lispworks sbcl)
 (defun ensure-method (gf lambda-expression
                          &key (method-class (generic-function-method-class gf))
                          (qualifiers ())
@@ -657,7 +657,7 @@
 (define-modify-macro nconcf (&rest lists) nconc)
 
 (defun fix-slot-initargs (initargs)
-  #+(or abcl allegro clisp clozure ecl lispworks mcl sbcl)
+  #+(or abcl allegro clisp clozure ecl clasp lispworks mcl sbcl)
   initargs
 
   #+(or cmu scl)

--- a/closer-mop.asd
+++ b/closer-mop.asd
@@ -10,6 +10,7 @@
    (:file "closer-mop-shared")
    (:file "closer-abcl"      :if-feature :abcl)
    (:file "closer-allegro"   :if-feature :allegro)
+   (:file "closer-clasp"     :if-feature :clasp)
    (:file "closer-clisp"     :if-feature :clisp)
    (:file "closer-clozure"   :if-feature :clozure)
    (:file "closer-cmu"       :if-feature :cmu)

--- a/closer-mop.asd
+++ b/closer-mop.asd
@@ -4,18 +4,17 @@
   :author "Pascal Costanza"
   :version "1.0.0"
   :licence "MIT-style license"
+  :serial t
   :components
   ((:file "closer-mop-packages")
-   (:file "closer-mop-shared" :depends-on ("closer-mop-packages"))
-   (:file
-    #+abcl	"closer-abcl"
-    #+allegro   "closer-allegro"
-    #+clisp     "closer-clisp"
-    #+clozure   "closer-clozure"
-    #+cmu       "closer-cmu"
-    #+ecl       "closer-ecl"
-    #+lispworks "closer-lispworks"
-    #+mcl       "closer-mcl"
-    #+sbcl      "closer-sbcl"
-    #+scl       "closer-scl"
-    :depends-on ("closer-mop-packages" "closer-mop-shared"))))
+   (:file "closer-mop-shared")
+   (:file "closer-abcl"      :if-feature :abcl)
+   (:file "closer-allegro"   :if-feature :allegro)
+   (:file "closer-clisp"     :if-feature :clisp)
+   (:file "closer-clozure"   :if-feature :clozure)
+   (:file "closer-cmu"       :if-feature :cmu)
+   (:file "closer-ecl"       :if-feature :ecl)
+   (:file "closer-lispworks" :if-feature :lispworks)
+   (:file "closer-mcl"       :if-feature :mcl)
+   (:file "closer-sbcl"      :if-feature :sbcl)
+   (:file "closer-scl"       :if-feature :scl)))


### PR DESCRIPTION
The read time conditionals used to lead to an invalid
asdf:system-definition on unsupported platforms which
broke even when just loading the .asd file.

rudimentary clasp support will come in a later PR.