### PR TITLE
Initial port to mezzano.

### DIFF
--- a/closer-mop-packages.lisp
+++ b/closer-mop-packages.lisp
@@ -19,7 +19,7 @@
   #+(or lispworks6 lispworks7)
   (:import-from #:hcl #:with-hash-table-locked)
 
-  #-(or clisp scl)
+  #-(or clisp scl mezzano)
   (:import-from
    #+abcl      #:ext
    #+allegro   #:excl
@@ -45,6 +45,7 @@
    #+mcl       #:ccl
    #+sbcl      #:sb-mop
    #+scl       #:clos
+   #+mezzano   #:mezzano.clos
 
    #:direct-slot-definition
    #:effective-slot-definition
@@ -62,11 +63,11 @@
    #:standard-slot-definition
    #:standard-writer-method
 
-   #-lispworks4.3 #:accessor-method-slot-definition
-   #-scl #:add-dependent
-   #-scl #:add-direct-method
-   #:add-direct-subclass
-   #-scl #:class-default-initargs
+   #-(or lispworks4.3 mezzano) #:accessor-method-slot-definition
+   #-(or scl mezzano) #:add-dependent
+   #-(or scl mezzano) #:add-direct-method
+   #-mezzano #:add-direct-subclass
+   #-(or scl mezzano) #:class-default-initargs
    #-scl #:class-direct-default-initargs
    #:class-direct-slots
    #:class-direct-subclasses
@@ -77,7 +78,7 @@
    #:class-slots
    #-(or clozure lispworks mcl) #:compute-applicable-methods-using-classes
    #:compute-class-precedence-list
-   #-(or lispworks4 lispworks5) #:compute-default-initargs
+   #-(or lispworks4 lispworks5 mezzano) #:compute-default-initargs
    #-clozure #:compute-discriminating-function
    #-(or clozure scl) #:compute-effective-method
    #:compute-effective-slot-definition
@@ -86,13 +87,13 @@
    #:effective-slot-definition-class
    #:ensure-class
    #:ensure-class-using-class
-   #:ensure-generic-function-using-class
+   #-mezzano #:ensure-generic-function-using-class
    #-lispworks #:eql-specializer-object
    #:extract-lambda-list
    #:extract-specializer-names
    #:finalize-inheritance
-   #-lispworks #:find-method-combination
-   #-(or lispworks scl) #:funcallable-standard-instance-access
+   #-(or lispworks mezzano) #:find-method-combination
+   #-(or lispworks scl mezzano) #:funcallable-standard-instance-access
    #-allegro #:generic-function-argument-precedence-order
    #:generic-function-declarations
    #:generic-function-lambda-list
@@ -101,16 +102,16 @@
    #:generic-function-methods
    #:generic-function-name
    #-lispworks #:intern-eql-specializer
-   #-(or allegro clisp clozure lispworks mcl scl) #:make-method-lambda
-   #-scl #:map-dependents
+   #-(or allegro clisp clozure lispworks mcl scl mezzano) #:make-method-lambda
+   #-(or scl mezzano) #:map-dependents
    #-clozure #:method-function
    #:method-generic-function
    #:method-lambda-list
    #:method-specializers
    #-lispworks4.3 #:reader-method-class
-   #-scl #:remove-dependent
-   #-scl #:remove-direct-method
-   #:remove-direct-subclass
+   #-(or scl mezzano) #:remove-dependent
+   #-(or scl mezzano) #:remove-direct-method
+   #-mezzano #:remove-direct-subclass
    #:set-funcallable-instance-function
    #:slot-boundp-using-class
    #:slot-definition-allocation
@@ -123,11 +124,11 @@
    #:slot-definition-writers
    #:slot-definition-type
    #:slot-makunbound-using-class
-   #:slot-value-using-class
-   #-lispworks #:specializer-direct-generic-functions
-   #:specializer-direct-methods
-   #-lispworks #:standard-instance-access
-   #-scl #:update-dependent
+   #-mezzano #:slot-value-using-class
+   #-(or lispworks mezzano) #:specializer-direct-generic-functions
+   #-mezzano #:specializer-direct-methods
+   #-(or lispworks mezzano) #:standard-instance-access
+   #-(or scl mezzano) #:update-dependent
    #:validate-superclass
    #-lispworks4.3 #:writer-method-class)
 
@@ -138,6 +139,7 @@
    #:effective-slot-definition
    #:eql-specializer
    #+lispworks #:eql-specializer*
+   #+mezzano #:eql-specializer
    #:forward-referenced-class
    #:funcallable-standard-class
    #:funcallable-standard-object
@@ -212,6 +214,7 @@
    #:generic-function-name
    #:intern-eql-specializer
    #+lispworks #:intern-eql-specializer*
+   #+mezzano #:intern-eql-specializer
    #:make-method-lambda
    #:map-dependents
    #:method-function
@@ -259,7 +262,7 @@
                    for symbol in symbols do
                    (push (symbol-name symbol)
                          (getf map (symbol-package symbol)))
-                   finally (return 
+                   finally (return
                             `(defpackage #:closer-common-lisp
                                (:nicknames #:c2cl)
                                (:use)


### PR DESCRIPTION
I'm porting McCLIM to mezzano, a lisp OS (https://github.com/froggey). McCLIM depends on closer-mop and  I've used #+mezzano to featurize closer-mop enough to load on mezzano and support McCLIM.  I don't think it's a complete port, but I'm not sure what would constitute a complete port ...
