### PR TITLE
Fix closer-mop.asd

### DIFF
--- a/closer-mop.asd
+++ b/closer-mop.asd
@@ -8,14 +8,17 @@
   :components
   ((:file "closer-mop-packages")
    (:file "closer-mop-shared")
-   (:file "closer-abcl"      :if-feature :abcl)
-   (:file "closer-allegro"   :if-feature :allegro)
-   (:file "closer-clasp"     :if-feature :clasp)
-   (:file "closer-clisp"     :if-feature :clisp)
-   (:file "closer-clozure"   :if-feature :clozure)
-   (:file "closer-cmu"       :if-feature :cmu)
-   (:file "closer-ecl"       :if-feature :ecl)
-   (:file "closer-lispworks" :if-feature :lispworks)
-   (:file "closer-mcl"       :if-feature :mcl)
-   (:file "closer-sbcl"      :if-feature :sbcl)
-   (:file "closer-scl"       :if-feature :scl)))
+   (:module "implementation"
+    :pathname ""
+    :components
+    ((:file "closer-abcl"      :if-feature :abcl)
+     (:file "closer-allegro"   :if-feature :allegro)
+     (:file "closer-clasp"     :if-feature :clasp)
+     (:file "closer-clisp"     :if-feature :clisp)
+     (:file "closer-clozure"   :if-feature :clozure)
+     (:file "closer-cmu"       :if-feature :cmu)
+     (:file "closer-ecl"       :if-feature :ecl)
+     (:file "closer-lispworks" :if-feature :lispworks)
+     (:file "closer-mcl"       :if-feature :mcl)
+     (:file "closer-sbcl"      :if-feature :sbcl)
+     (:file "closer-scl"       :if-feature :scl)))))


### PR DESCRIPTION
Move the implementation-dependent files in a module, because the interaction of `:serial t` and `:if-feature` means that all Lisp files except the first depend on the previous which has been cancelled out. This causes some incremental or parallel builds to fail.